### PR TITLE
Sending IDSR Code when creating AR.

### DIFF
--- a/accel.isdr.sync/api/ploneapi.py
+++ b/accel.isdr.sync/api/ploneapi.py
@@ -73,13 +73,6 @@ class PloneApi:
         result = self.send_request(url, params)
         return result
 
-    def getUID(self, obj_id, portal_type=None):
-        url = self.jsonapi_url + '/plone/api/1.0/search?id='+obj_id
-        if portal_type:
-            url += '&portal_type='+portal_type
-        result = self.send_request(url)
-        return result['items'][0]['uid']
-
     def send_request(self, url, params=None):
         try:
             if params:

--- a/accel.isdr.sync/database/database.py
+++ b/accel.isdr.sync/database/database.py
@@ -102,7 +102,7 @@ class Database:
             ar_cc_contact = ''
             ar_sampler_phone = c['sampler_phone']
             ar_case_id = c['case_id']
-            ar_patient_record_id = c.get('patient_record_id','')
+            ar_patient_record_id = c.get('patient_record_id', '')
             ar_reporting_health_facility = facility_code
             ar_patient_uid = ''
             ar_sampling_date = c['date_sampled'].strftime("%Y-%m-%d %H:%M")
@@ -110,14 +110,16 @@ class Database:
             ar_sample_type = c['sample_type']
             ar_analysis_specification = ''
             ar_analyses_requested = c['analyses_requested']
-            ar_client_order_number = c.get('patient_record_id','')
+            ar_client_order_number = c.get('patient_record_id', '')
+            ar_idsr_code = "%s-%s" % (facility_code, ar_case_id)
 
             ar = AnalysisRequest(ar_contact_uid, ar_cc_contact, ar_sampler_phone,
                                  ar_case_id, ar_patient_record_id,
                                  ar_reporting_health_facility, ar_patient_uid,
                                  ar_sampling_date, ar_sample_type,
                                  ar_analysis_specification,
-                                 ar_analyses_requested, ar_client_order_number)
+                                 ar_analyses_requested, ar_client_order_number,
+                                 ar_idsr_code)
             idsr_form = IDSRForm(form_id, patient, contact, ar)
             idsr_forms.append(idsr_form)
 

--- a/accel.isdr.sync/database/models/analysisrequest.py
+++ b/accel.isdr.sync/database/models/analysisrequest.py
@@ -6,7 +6,7 @@ class AnalysisRequest():
     def __init__(self, contact_uid, cc_contact, sampler_phone, case_id,
                  patient_record_id, reporting_health_facility, patient_uid,
                  sampling_date, sample_type, analysis_specification,
-                 analyses_requested, client_order_number):
+                 analyses_requested, client_order_number, idsr_code):
         """
         Initializes the AnalysisRequest object.
         """
@@ -30,6 +30,7 @@ class AnalysisRequest():
         # Profiles in Bika
         self.analyses_requested = analyses_requested
         self.client_order_number = client_order_number
+        self.idsr_code = idsr_code
 
     def getContact(self):
         return self.contact
@@ -76,7 +77,9 @@ class AnalysisRequest():
                   'CCContact': self.cc_contact,
                   'CCEmails': self.sampler_phone,
                   'Client': self.reporting_health_facility,
-                  'Batch': self.case_id,
+                  # Batch is empty for now, might be used in the future.
+                  # 'Batch': self.case_id,
+                  'Batch': '',
                   'ClientPatientID': self.patient_uid,
                   'Patient': "uid:" + self.patient_uid,
                   'SamplingDate': self.sampling_date,
@@ -84,8 +87,7 @@ class AnalysisRequest():
                   'Specification': '',
                   'ClientOrderNumber': self.client_order_number,
                   'Profiles': "uid:" + self.analyses_requested,
-                  'Services': [""]
-                  # TODO Analyses MUST BE REMOVED!
-                  # "Analyses": ["5d7c07665dfc43ddbb8d8c354740e412"]
+                  'Services': [""],
+                  'IDSRCode': self.idsr_code
                   }
         return result

--- a/accel.isdr.sync/run.py
+++ b/accel.isdr.sync/run.py
@@ -249,7 +249,7 @@ class Run:
                 # PATIENT CREATION
                 p_result = self.api.create(f.getPatient())
                 if not p_result.get('success', ''):
-                    message = c_result.get('message', '')
+                    message = p_result.get('message', '')
                     status = 'Fail'
                     self.db.update_status(f.getId(), 'failed')
                     self.insert_log(status, message,
@@ -283,7 +283,7 @@ class Run:
                 ar.setContactUid(c_id)
                 ar_result = self.api.create(ar)
                 if not ar_result.get('success', ''):
-                    message = str(c_result.get('message', ''))
+                    message = str(ar_result.get('message', ''))
                     status = 'Fail'
                     self.db.update_status(f.getId(), 'failed')
                     self.insert_log(status, message,

--- a/accel.isdr.sync/run.py
+++ b/accel.isdr.sync/run.py
@@ -249,7 +249,7 @@ class Run:
                 # PATIENT CREATION
                 p_result = self.api.create(f.getPatient())
                 if not p_result.get('success', ''):
-                    message = p_result['message']
+                    message = c_result.get('message', '')
                     status = 'Fail'
                     self.db.update_status(f.getId(), 'failed')
                     self.insert_log(status, message,
@@ -260,12 +260,12 @@ class Run:
                 status = 'Success'
                 self.insert_log(status, message,
                                 'Patient', f.getId())
-                p_uid = self.api.getUID(p_id, "Patient")
+                p_uid = p_result['obj_uid']
 
                 # CLIENT CONTACT CREATION
                 c_result = self.api.create(f.getContact())
                 if not c_result.get('success', ''):
-                    message = c_result['message']
+                    message = c_result.get('message', '')
                     status = 'Fail'
                     self.db.update_status(f.getId(), 'failed')
                     self.insert_log(status, message,
@@ -283,7 +283,7 @@ class Run:
                 ar.setContactUid(c_id)
                 ar_result = self.api.create(ar)
                 if not ar_result.get('success', ''):
-                    message = str(ar_result['message'])
+                    message = str(c_result.get('message', ''))
                     status = 'Fail'
                     self.db.update_status(f.getId(), 'failed')
                     self.insert_log(status, message,
@@ -298,6 +298,7 @@ class Run:
             message = str(e)
             status = 'Fail'
             self.insert_log(status, message, 'AR & Patient')
+            self.db.update_status(f.getId(), 'failed')
         threading.Timer(intervals['idsrform'], self.processForms).start()
 
     def insert_log(self, status, message, content_type, idsr_id=None):

--- a/accel.isdr.sync/utils/config.ini
+++ b/accel.isdr.sync/utils/config.ini
@@ -1,8 +1,8 @@
 [bika_lims]
-plone_site_url = http://localhost:8080/Plone
+plone_site_url = http://localhost:8081/TappitaLab
 jsonapi_username = admin
-jsonapi_password = D4YQbRCztORY
-plone_site_name = Plone
+jsonapi_password = VzvqwitQVW18
+plone_site_name = TappitaLab
 
 [database]
 host = localhost

--- a/accelidsr/mod_idsrentry/forms/d.py
+++ b/accelidsr/mod_idsrentry/forms/d.py
@@ -32,7 +32,8 @@ class IdsrEntryStepD1Form(AbstractIdsrEntryStepForm):
 
     case_inout_patient = RadioField(
         'In/Out Patient',
-        choices=[('in', 'In Patient'), ('out', 'Out Patient'), 'unk', 'Not Indicated'])
+        choices=[('in', 'In Patient'),
+                 ('out', 'Out Patient'), ('unk', 'Not Indicated')])
 
     case_outcome = RadioField(
         'Outcome',


### PR DESCRIPTION
Now Bika Accel has IDSR Code field for AR objects. So, when creating ARs via JSON API, system sends `client_id + case_id` as IDSR Code. 

Also Removed getUID method, because Bika now returns UID of new created object in response JSON.

Config file was in ignore file always, but now it appears in changed files. Anyways, not important at all.