### PR TITLE
Show IDSR Codes in Submission Forms

### DIFF
--- a/accelidsr/templates/idsrentry/_formhelpers.html
+++ b/accelidsr/templates/idsrentry/_formhelpers.html
@@ -84,3 +84,9 @@
     </ul>
 </div>
 {% endmacro%}
+
+{% macro render_idsrcode(form) %}
+{% set idsrdict = form.getIdsrObject().getDict() if form.getIdsrObject() else {} %}
+{% set code = ("%s - %s - %s") % (idsrdict.get('county_code','??'),idsrdict.get('facility_code','??'),idsrdict.get('case_id','??'))  %}
+<h2>{{ code }}</h2>
+{% endmacro%}

--- a/accelidsr/templates/idsrentry/index.html
+++ b/accelidsr/templates/idsrentry/index.html
@@ -323,6 +323,8 @@ IDSR Input Form
 {% from "idsrentry/_formhelpers.html" import render_substepsnav %}
 {% from "idsrentry/_formhelpers.html" import render_fields %}
 {% from "idsrentry/_formhelpers.html" import render_formfooter %}
+{% from "idsrentry/_formhelpers.html" import render_idsrcode %}
+{{ render_idsrcode(form) }}
 {{ render_stepsnav(form, steps) }}
 {{ render_substepsnav(form)}}
 <form action="" method="post" id="{{ form.step }}" name="{{ form.step }}">


### PR DESCRIPTION
IDSR Codes are now visible in Submission Forms. If any of necessary parameters (county code, client id, case id) is missing, will be displayed as '??' (double question marks).